### PR TITLE
Use uniqueString to create deterministic ACR and Storage Account resource names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,12 @@ jobs:
       with:
         creds: ${{ secrets.AzureSPN }}
 
+    - name: Get ACR Login Server
+      run: |
+        # Retrieve ACR Login Server value from deployment output
+        ACR_LOGIN_SERVER=$(az deployment group show -g ${{ env.RESOURCE_GROUP_NAME }} -n main --query properties.outputs.acrLoginServer.value | tr -d '"')
+        echo "ACR_LOGIN_SERVER=$ACR_LOGIN_SERVER" >> $GITHUB_ENV
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
@@ -83,43 +89,43 @@ jobs:
         # see https://cloudarchitected.com/2021/09/logging-into-acr-in-github-actions/
         # see https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#calling-post-oauth2exchange-to-get-an-acr-refresh-token
         access_token=$(az account get-access-token --query accessToken -o tsv)
-        refresh_token=$(curl https://${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/oauth2/exchange -v -d "grant_type=access_token&service=${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io&access_token=$access_token" | jq -r .refresh_token)
+        refresh_token=$(curl https://${{ env.ACR_LOGIN_SERVER }}/oauth2/exchange -v -d "grant_type=access_token&service=${{ env.ACR_LOGIN_SERVER }}&access_token=$access_token" | jq -r .refresh_token)
         # The null GUID 0000... tells the container registry that this is an ACR refresh token during the login flow
-        docker login -u 00000000-0000-0000-0000-000000000000 --password-stdin ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io <<< "$refresh_token"
+        docker login -u 00000000-0000-0000-0000-000000000000 --password-stdin ${{ env.ACR_LOGIN_SERVER }} <<< "$refresh_token"
 
     - name: Build and push Silo image to registry
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.SILO_IMAGE_NAME }}:${{ github.sha }}
+        tags: ${{ env.ACR_LOGIN_SERVER }}/${{ env.SILO_IMAGE_NAME }}:${{ github.sha }}
         file: ${{ env.SILO_DOCKER_FILE_PATH }}
     
     - name: Build and push Dashboard image to registry
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.DASHBOARD_IMAGE_NAME }}:${{ github.sha }}
+        tags: ${{ env.ACR_LOGIN_SERVER }}/${{ env.DASHBOARD_IMAGE_NAME }}:${{ github.sha }}
         file: ${{ env.DASHBOARD_DOCKER_FILE_PATH }}
 
     - name: Build and push Minimal Client image to registry
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.MINIMAL_CLIENT_IMAGE_NAME }}:${{ github.sha }}
+        tags: ${{ env.ACR_LOGIN_SERVER }}/${{ env.MINIMAL_CLIENT_IMAGE_NAME }}:${{ github.sha }}
         file: ${{ env.MINIMAL_CLIENT_DOCKER_FILE_PATH }}
 
     - name: Build and push Worker Service Client image to registry
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.WORKERSERVICE_CLIENT_IMAGE_NAME }}:${{ github.sha }}
+        tags: ${{ env.ACR_LOGIN_SERVER }}/${{ env.WORKERSERVICE_CLIENT_IMAGE_NAME }}:${{ github.sha }}
         file: ${{ env.WORKERSERVICE_CLIENT_DOCKER_FILE_PATH }}
 
     - name: Build and push Scaler image to registry
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.SCALER_IMAGE_NAME }}:${{ github.sha }}
+        tags: ${{ env.ACR_LOGIN_SERVER }}/${{ env.SCALER_IMAGE_NAME }}:${{ github.sha }}
         file: ${{ env.SCALER_DOCKER_FILE_PATH }}
 
   deploy:
@@ -146,15 +152,21 @@ jobs:
 
           az extension add --name containerapp --yes
 
+    - name: Get ACR Login Server
+      run: |
+        # Retrieve ACR Login Server value from deployment output
+        ACR_LOGIN_SERVER=$(az deployment group show -g ${{ env.RESOURCE_GROUP_NAME }} -n main --query properties.outputs.acrLoginServer.value | tr -d '"')
+        echo "ACR_LOGIN_SERVER=$ACR_LOGIN_SERVER" >> $GITHUB_ENV
+
     - name: Deploy Silo
       uses: azure/CLI@v1
       with:
         inlineScript: >
           echo "Deploying Silo"
           
-          az containerapp registry set -n silo -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io
+          az containerapp registry set -n silo -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.ACR_LOGIN_SERVER }}
 
-          az containerapp update -n silo -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.SILO_IMAGE_NAME }}:${{ github.sha }}
+          az containerapp update -n silo -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.ACR_LOGIN_SERVER }}/${{ env.SILO_IMAGE_NAME }}:${{ github.sha }}
 
     - name: Deploy Dashboard
       uses: azure/CLI@v1
@@ -162,9 +174,9 @@ jobs:
         inlineScript: >
           echo "Deploying Dashboard"
           
-          az containerapp registry set -n dashboard -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io
+          az containerapp registry set -n dashboard -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.ACR_LOGIN_SERVER }}
 
-          az containerapp update -n dashboard -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.DASHBOARD_IMAGE_NAME }}:${{ github.sha }}
+          az containerapp update -n dashboard -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.ACR_LOGIN_SERVER }}/${{ env.DASHBOARD_IMAGE_NAME }}:${{ github.sha }}
 
     - name: Deploy Minimal API Client
       uses: azure/CLI@v1
@@ -172,9 +184,9 @@ jobs:
         inlineScript: >
           echo "Deploying Minimal API Client"
           
-          az containerapp registry set -n minimalapiclient -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io
+          az containerapp registry set -n minimalapiclient -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.ACR_LOGIN_SERVER }}
 
-          az containerapp update -n minimalapiclient -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.MINIMAL_CLIENT_IMAGE_NAME }}:${{ github.sha }}
+          az containerapp update -n minimalapiclient -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.ACR_LOGIN_SERVER }}/${{ env.MINIMAL_CLIENT_IMAGE_NAME }}:${{ github.sha }}
 
     - name: Deploy Worker Service Client
       uses: azure/CLI@v1
@@ -182,9 +194,9 @@ jobs:
         inlineScript: >
           echo "Deploying Worker Service Client"
           
-          az containerapp registry set -n workerserviceclient -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io
+          az containerapp registry set -n workerserviceclient -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.ACR_LOGIN_SERVER }}
 
-          az containerapp update -n workerserviceclient -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.WORKERSERVICE_CLIENT_IMAGE_NAME }}:${{ github.sha }}
+          az containerapp update -n workerserviceclient -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.ACR_LOGIN_SERVER }}/${{ env.WORKERSERVICE_CLIENT_IMAGE_NAME }}:${{ github.sha }}
 
     - name: Deploy Scaler
       uses: azure/CLI@v1
@@ -192,9 +204,9 @@ jobs:
         inlineScript: >
           echo "Deploying Scaler"
           
-          az containerapp registry set -n scaler -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io
+          az containerapp registry set -n scaler -g ${{ env.RESOURCE_GROUP_NAME }} --server ${{ env.ACR_LOGIN_SERVER }}
 
-          az containerapp update -n scaler -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io/${{ env.SCALER_IMAGE_NAME }}:${{ github.sha }}
+          az containerapp update -n scaler -g ${{ env.RESOURCE_GROUP_NAME }} -i ${{ env.ACR_LOGIN_SERVER }}/${{ env.SCALER_IMAGE_NAME }}:${{ github.sha }}
 
     - name: logout
       run: >

--- a/Azure/main.bicep
+++ b/Azure/main.bicep
@@ -1,7 +1,7 @@
 param location string = resourceGroup().location
 
 resource acr 'Microsoft.ContainerRegistry/registries@2021-09-01' = {
-  name: toLower('${resourceGroup().name}acr')
+  name: toLower('${uniqueString(resourceGroup().id)}acr')
   location: location
   sku: {
     name: 'Basic'
@@ -117,3 +117,4 @@ module workerserviceclient 'workerserviceclient.bicep' = {
   }
 }
 
+output acrLoginServer string = acr.properties.loginServer

--- a/Azure/main.bicep
+++ b/Azure/main.bicep
@@ -19,7 +19,7 @@ module env 'environment.bicep' = {
 }
 
 module storage 'storage.bicep' = {
-  name: toLower('${resourceGroup().name}strg')
+  name: toLower('${uniqueString(resourceGroup().id)}strg')
   params: {
     location: location
   }

--- a/Azure/storage.bicep
+++ b/Azure/storage.bicep
@@ -1,7 +1,7 @@
 param location string = resourceGroup().location
 
 resource storage 'Microsoft.Storage/storageAccounts@2021-02-01' = {
-  name: toLower('${resourceGroup().name}strg')
+  name: toLower('${uniqueString(resourceGroup().id)}strg')
   location: location
   kind: 'StorageV2'
   sku: {


### PR DESCRIPTION
## Purpose

Prior to this PR, names for the Azure Container Registry (ACR) and Storage Account (SA) resources were based on the resource group name. Resource groups do not have the same restrictions ACR and SA have and therefore the deployment will fail if the resource group is not named according to ACR and SA requirements.

* Update Bicep templates to use `uniqueString` function to create names for ACR and Storage Account 
* Update `deploy.yml` to retrieve and use the ACR Login Server deployment output value and place in `ACR_LOGIN_SERVER` environment variable
* Update `deploy.yml` to replace occurrences of `${{ env.RESOURCE_GROUP_NAME }}acr.azurecr.io` with `${{ env.ACR_LOGIN_SERVER }}`

## Does this introduce a breaking change?
```
[x] Yes
[ ] No
```
Will change the ACR and SA names if you have already deployed and therefore will break existing environments.

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Merge onto the `deploy` branch

* Test the code
N/A

## What to Check
Verify that the following are valid
* Deployment succeeds even with a resource group name with '-`, UPPERCASE characters, or names longer than 20 characters
